### PR TITLE
Upgrade dependecies

### DIFF
--- a/RNKLineView.podspec
+++ b/RNKLineView.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.swift_version = "4.0"
 
   s.dependency "React"
-  s.dependency 'lottie-ios', '~> 3.2.3'
+  s.dependency 'lottie-ios', '~> 4.5.0'
 
 end
 

--- a/ios/Classes/HTKLineView.swift
+++ b/ios/Classes/HTKLineView.swift
@@ -117,7 +117,7 @@ class HTKLineView: UIScrollView {
         lastLoadAnimationSource = configManager.closePriceRightLightLottieSource
 
         DispatchQueue.global().async { [weak self] in
-            guard let this = self, let data = this.configManager.closePriceRightLightLottieSource.data(using: String.Encoding.utf8), let animation = try? JSONDecoder().decode(Animation.self, from: data) else {
+            guard let this = self, let data = this.configManager.closePriceRightLightLottieSource.data(using: String.Encoding.utf8), let animation = try? JSONDecoder().decode(LottieAnimation.self, from: data) else {
                 return
             }
             DispatchQueue.main.async {

--- a/ios/Classes/HTKLineView.swift
+++ b/ios/Classes/HTKLineView.swift
@@ -38,7 +38,7 @@ class HTKLineView: UIScrollView {
 
     var childDraw: HTKLineDrawProtocol?
 
-    var animationView = AnimationView.init()
+    var animationView = LottieAnimationView()
 
     var lastLoadAnimationSource = ""
 


### PR DESCRIPTION
This pull request updates the Lottie dependency to a newer major version and refactors related code to use the updated API in the `HTKLineView` class. The most important changes are grouped below:

**Dependency Upgrade:**

* Updated the Lottie iOS dependency in `RNKLineView.podspec` from version `~> 3.2.3` to `~> 4.5.0`, ensuring compatibility with the latest features and bug fixes.

**Code Refactoring for Lottie v4:**

* Replaced usage of `AnimationView` with `LottieAnimationView` to match the updated Lottie v4 API in `HTKLineView.swift`.
* Changed decoding from `Animation` to `LottieAnimation` when loading Lottie animation data, ensuring proper deserialization with the new version's model.